### PR TITLE
Fix ReDOS vulnerability in fast-xml-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@workos-inc/authkit-nextjs": "^0.5.3",
     "@workos-inc/node": "^7.4.0",
     "axios": "^1.6.8",
+    "fast-xml-parser": "^5.0.1",
     "next": "14.2.3",
     "react": "^18",
     "react-country-state-city": "^1.1.0",


### PR DESCRIPTION
Related to #7

Update `fast-xml-parser` dependency to version 5.0.1 to fix ReDOS vulnerability.

* **package.json**
  - Add `fast-xml-parser` dependency with version `^5.0.1`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/actus7/portalempregos/issues/7?shareId=dad94420-4742-41eb-83b8-4132939851db).